### PR TITLE
Model\Annotations fix nullable annotation

### DIFF
--- a/src/Db/Model/Annotations/Metadata.php
+++ b/src/Db/Model/Annotations/Metadata.php
@@ -103,7 +103,7 @@ class Metadata implements StrategyInterface
                 /**
                  * Check for the 'nullable' parameter in the 'Column' annotation
                  */
-                if (!$collection->has('Identity') && !empty($arguments['nullable'])) {
+                if (!$collection->has('Identity') && !empty($arguments['nullable']) && $arguments['nullable'] == false) {
                     $nullables[] = $columnName;
                 }
 
@@ -296,7 +296,7 @@ class Metadata implements StrategyInterface
             /**
              * Check for the 'nullable' parameter in the 'Column' annotation.
              */
-            if (!$collection->has('Identity') && !empty($arguments['nullable'])) {
+            if (!$collection->has('Identity') && !empty($arguments['nullable']) && $arguments['nullable'] == false) {
                 $modelInfo['columns'][$columnName]['nullable'] = $arguments['nullable'];
             }
 


### PR DESCRIPTION
- nullable allows column to a null value

Because it is passed in https://github.com/ovr/framework/blob/b9354b2efe16dcfe24850eae4a391e8b5a92f14e/src/Db/Model/Annotations/Metadata.php#L139

``` php
/**
* @Column(name="lastname", type="string", length=45, nullable=true)
* @var string
*/
public $lastname;
```

Without it, $lastname cant be null
